### PR TITLE
Add support for response compression

### DIFF
--- a/server.go
+++ b/server.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/gorilla/pat"
+	"github.com/gorilla/handlers"
 	"github.com/ian-kent/go-log/log"
 	"golang.org/x/crypto/bcrypt"
 )
@@ -102,7 +103,8 @@ func Listen(httpBindAddr string, Asset func(string) ([]byte, error), exitCh chan
 	pat := pat.New()
 	registerCallback(pat)
 
-	auth := BasicAuthHandler(pat)
+	compress := handlers.CompressHandler(pat)
+	auth := BasicAuthHandler(compress)
 
 	err := http.ListenAndServe(httpBindAddr, auth)
 	if err != nil {


### PR DESCRIPTION
This utilises the [Gorilla CompressHandler](https://github.com/gorilla/handlers) to compress responses if the client supports it.

The primary advantage is when MailHog is that this drastically reduces the response times when operating over a remote link. Without it, a single request for 50 messages can easily start reaching 10MB.

Given the push-button approach that MailHog is intended to support, requiring it to be deployed behind a "real" web-server seems like an extra unnecessary complication.

For this to work as expected, mailhog/MailHog-UI#9 is necessary to provide valid content types for all static content.
